### PR TITLE
fix: add logic to disable ssl connect to k8s api for >= 3.13 python

### DIFF
--- a/.github/linters/.flake8
+++ b/.github/linters/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 120

--- a/docker/status_provisioner.py
+++ b/docker/status_provisioner.py
@@ -12,12 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
 import os
 import time
 
 from jsonpath_ng.ext import parse
-
-from libraries import KubernetesLibrary, Condition, ConditionReason, ConditionType, CustomResource, DEFAULT_TIMEOUT
+from libraries import (
+    DEFAULT_TIMEOUT,
+    Condition,
+    ConditionReason,
+    ConditionType,
+    CustomResource,
+    KubernetesLibrary,
+)
 
 
 def get_resources_statuses(resources: str, kubernetes_library: KubernetesLibrary) -> []:
@@ -29,8 +36,7 @@ def get_resources_statuses(resources: str, kubernetes_library: KubernetesLibrary
         print(f'Processing [{resource}] resource')
         parts = resource.split()
         if len(parts) != 2:
-            raise Exception(f'Resource description must contain 2 parts: type and name. '
-                            f'But [{resource}] is received.')
+            raise Exception(f'Resource description must contain 2 parts: type and name. But [{resource}] is received.')
         resource_type = parts[0].lower()
         resource_name = parts[1]
         start_time = time.time()
@@ -104,12 +110,15 @@ if __name__ == '__main__':
     namespace = os.getenv('NAMESPACE')
     resource_to_set_status = os.getenv('RESOURCE_TO_SET_STATUS')
     treat_status_as_field = os.getenv('TREAT_STATUS_AS_FIELD', False)
+
     if (monitored_resources or monitored_custom_resources) and namespace and resource_to_set_status:
         condition_reason = os.getenv('CONDITION_REASON', ConditionReason.DEFAULT)
         successful_condition_type = os.getenv('SUCCESSFUL_CONDITION_TYPE', ConditionType.SUCCESSFUL)
         failed_condition_type = os.getenv('FAILED_CONDITION_TYPE', ConditionType.FAILED)
+
         kubernetes_library = KubernetesLibrary(namespace, resource_to_set_status)
         condition_library = Condition(condition_reason, successful_condition_type)
+
         successful_status_message = 'All components are in ready status.'
 
         # Update status condition with 'In Progress' state


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

During the use of deployment-status-provisioner version 0.2.0, in logs, print the error:

<details>
  <summary>[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: Missing Authority Key Identifier</summary>

```bash
Status Provisioner have started calculating the state of the cluster
Traceback (most recent call last):
  File "/usr/local/lib/python3.13/site-packages/urllib3/connectionpool.py", line 464, in _make_request
    self._validate_conn(conn)
    ~~~~~~~~~~~~~~~~~~~^^^^^^
  File "/usr/local/lib/python3.13/site-packages/urllib3/connectionpool.py", line 1093, in _validate_conn
    conn.connect()
    ~~~~~~~~~~~~^^
  File "/usr/local/lib/python3.13/site-packages/urllib3/connection.py", line 790, in connect
    sock_and_verified = _ssl_wrap_socket_and_match_hostname(
        sock=sock,
    ...<14 lines>...
        assert_fingerprint=self.assert_fingerprint,
    )
  File "/usr/local/lib/python3.13/site-packages/urllib3/connection.py", line 969, in _ssl_wrap_socket_and_match_hostname
    ssl_sock = ssl_wrap_socket(
        sock=sock,
    ...<8 lines>...
        tls_in_tls=tls_in_tls,
    )
  File "/usr/local/lib/python3.13/site-packages/urllib3/util/ssl_.py", line 480, in ssl_wrap_socket
    ssl_sock = _ssl_wrap_socket_impl(sock, context, tls_in_tls, server_hostname)
  File "/usr/local/lib/python3.13/site-packages/urllib3/util/ssl_.py", line 524, in _ssl_wrap_socket_impl
    return ssl_context.wrap_socket(sock, server_hostname=server_hostname)
           ~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.13/ssl.py", line 455, in wrap_socket
    return self.sslsocket_class._create(
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
        sock=sock,
        ^^^^^^^^^^
    ...<5 lines>...
        session=session
        ^^^^^^^^^^^^^^^
    )
    ^
  File "/usr/local/lib/python3.13/ssl.py", line 1076, in _create
    self.do_handshake()
    ~~~~~~~~~~~~~~~~~^^
  File "/usr/local/lib/python3.13/ssl.py", line 1372, in do_handshake
    self._sslobj.do_handshake()
    ~~~~~~~~~~~~~~~~~~~~~~~~~^^
ssl.SSLCertVerificationError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: Missing Authority Key Identifier (_ssl.c:1032)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/lib/python3.13/site-packages/urllib3/connectionpool.py", line 787, in urlopen
    response = self._make_request(
        conn,
    ...<10 lines>...
        **response_kw,
    )
  File "/usr/local/lib/python3.13/site-packages/urllib3/connectionpool.py", line 488, in _make_request
    raise new_e
urllib3.exceptions.SSLError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: Missing Authority Key Identifier (_ssl.c:1032)
```

</details>

## Root cause

It's a known issue for the Kubernetes Python client and Python 3.13 related to changes in Python SSL
https://docs.python.org/3/whatsnew/3.13.html#ssl

Kubernetes client issue:
https://github.com/kubernetes-client/python/issues/2394#issuecomment-2884974440

## Solution

Currently doesn't exist.

But as WA, we can disable SSL in the Kubernetes client.

## QA Instructions, Screenshots, Recordings

Deploy any service using this `deployment-status-provisioner` and check that in the logs there are no SSL errors.

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: not needed
- [ ] I need help with writing tests
